### PR TITLE
Visit Occurrence Report - Table Order

### DIFF
--- a/src/components/DomainTable.vue
+++ b/src/components/DomainTable.vue
@@ -91,6 +91,8 @@
           item-key="CONCEPT_ID"
           :items-per-page="10"
           :search="search"
+          :sort-by="['PERCENT_PERSONS']"
+          :sort-desc="[true, false]"
         >
           <template v-slot:item.CONCEPT_ID="{ item }">
             <v-layout flex-end


### PR DESCRIPTION
Hello!

Fixed the following issue: https://github.com/OHDSI/Ares/issues/4

The thing is that there was no explicit sorting of any columns in the data table regardless of the displayed report. It renders the csv content as is.

The solution is to add the default sorting by % People to all the reports displayed by the DomainTable component so that the default sorting stayed consistant regardless of the source data order.