### PR TITLE
Record Count Proportion by Age, Sex, and Year

### DIFF
--- a/src/components/ConceptReport.vue
+++ b/src/components/ConceptReport.vue
@@ -523,8 +523,9 @@ export default {
             field: "TRELLIS_NAME",
             type: "nominal",
             title: null,
+            sort: {"field": "id"},
             rows: 1,
-            spacing: 5,
+            spacing: 20,
             header: {
               title: "Age Deciles",
               labelOrient: "top",
@@ -1137,7 +1138,20 @@ export default {
           }
 
           self.specRecordProportionByAgeSexYear.data = {
-            values: self.conceptData.PREVALENCE_BY_GENDER_AGE_YEAR,
+            values: self.conceptData.PREVALENCE_BY_GENDER_AGE_YEAR.map((item) => ({
+              ...item,
+              TRELLIS_NAME: item.TRELLIS_NAME.split(`-`).map((num) => parseInt(num)),
+            }))
+                .sort(
+                    (a, b) =>
+                        a.TRELLIS_NAME[0] - b.TRELLIS_NAME[0] ||
+                        a.TRELLIS_NAME[1] - b.TRELLIS_NAME[1],
+                )
+                .map((item, index) => ({
+                  ...item,
+                  TRELLIS_NAME: item.TRELLIS_NAME.join(`-`),
+                  id: index,
+                })),
           };
           self.specRecordProportionByMonth.data = {
             values: self.conceptData.PREVALENCE_BY_MONTH,

--- a/src/components/DeathReport.vue
+++ b/src/components/DeathReport.vue
@@ -173,6 +173,7 @@ export default {
             field: "TRELLIS_NAME",
             type: "nominal",
             title: null,
+            sort: {"field": "id"},
             rows: 1,
             spacing: 5,
             header: {
@@ -280,7 +281,20 @@ export default {
           embed("#viz-deathbytype", vm.specDeathByType);
 
           vm.specRecordProportionByAgeSexYear.data = {
-            values: vm.deathData.PREVALENCE_BY_GENDER_AGE_YEAR,
+            values: vm.deathData.PREVALENCE_BY_GENDER_AGE_YEAR.map((item) => ({
+              ...item,
+              TRELLIS_NAME: item.TRELLIS_NAME.split(`-`).map((num) => parseInt(num)),
+            }))
+                .sort(
+                    (a, b) =>
+                        a.TRELLIS_NAME[0] - b.TRELLIS_NAME[0] ||
+                        a.TRELLIS_NAME[1] - b.TRELLIS_NAME[1],
+                )
+                .map((item, index) => ({
+                  ...item,
+                  TRELLIS_NAME: item.TRELLIS_NAME.join(`-`),
+                  id: index,
+                })),
           };
           embed(
             "#viz-recordproportionbyagesexyear",


### PR DESCRIPTION
Closes https://github.com/OHDSI/Ares/issues/1

The issue was that the vega library sorted columns based on the ranges provided in a string (which resulted in alphabetical order).

The solution is to add an additional field containing the object's position to sort by.