### PR TITLE
Changing data source does not refresh report

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,7 @@
         <v-btn to="/help">
           <v-icon dark>mdi-help-circle-outline</v-icon>
         </v-btn>
-        <v-btn to="/_network/overview"
+        <v-btn to="/network/overview"
           ><v-icon dark>mdi-database</v-icon></v-btn
         >
         <v-btn to="/"
@@ -47,8 +47,6 @@ export default {
     };
   },
   name: "ARES",
-  components: {
-  }
 };
 </script>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,11 +21,9 @@
         <v-btn to="/help">
           <v-icon dark>mdi-help-circle-outline</v-icon>
         </v-btn>
-
         <v-btn to="/_network/overview"
           ><v-icon dark>mdi-database</v-icon></v-btn
         >
-
         <v-btn to="/"
           ><v-img
             :src="require('./assets/icon.png')"
@@ -49,6 +47,8 @@ export default {
     };
   },
   name: "ARES",
+  components: {
+  }
 };
 </script>
 

--- a/src/components/ConceptReport.vue
+++ b/src/components/ConceptReport.vue
@@ -5,7 +5,6 @@
     </div>
     <v-container v-if="!componentFailed">
       <v-responsive min-width="900">
-        <explorer></explorer>
         <v-layout class="ma-0 mb-6 text-uppercase text-h6">{{
           conceptName
         }}</v-layout>
@@ -300,7 +299,6 @@
 import axios from "axios";
 import embed from "vega-embed";
 import error from "./Error.vue";
-import explorer from "./Explorer.vue";
 import * as d3 from "d3-time-format";
 import * as d3Format from "d3-format";
 import InfoPanel from "./InfoPanel.vue";
@@ -938,18 +936,20 @@ export default {
   },
   components: {
     error,
-    explorer,
     InfoPanel,
   },
   created() {
     this.load();
+  },
+  updated() {
+    this.load()
   },
   methods: {
     getSourceConceptReportLink: function () {
       return (
         "/_datasource/" +
         this.$route.params.cdm +
-        "/concept/" +
+            "/" +
         this.$route.params.domain +
         "/" +
         this.$route.params.concept +

--- a/src/components/ConceptReport.vue
+++ b/src/components/ConceptReport.vue
@@ -947,7 +947,7 @@ export default {
   methods: {
     getSourceConceptReportLink: function () {
       return (
-        "/_datasource/" +
+        "/datasource/" +
         this.$route.params.cdm +
             "/" +
         this.$route.params.domain +
@@ -967,7 +967,7 @@ export default {
     },
     getNetworkConceptRoute() {
       return (
-        "/_network/concept/" +
+        "/network/concept/" +
         this.$route.params.domain +
         "/" +
         this.$route.params.concept +
@@ -977,11 +977,11 @@ export default {
     navigateToDataQuality() {
       this.$router.push({
         path:
-          "/_cdm/" +
+          "/cdm/" +
           this.$route.params.cdm +
           "/" +
           this.$route.params.release +
-          "/quality?tab=results&conceptFailFilter=" +
+          "/data_quality?tab=results&conceptFailFilter=" +
           this.$route.params.concept,
       });
     },

--- a/src/components/DataQualityHistory.vue
+++ b/src/components/DataQualityHistory.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <explorer></explorer>
     <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
       <v-card-title>Historical Data Quality</v-card-title>
       <div class="viz-container" id="viz-dataqualityresults"></div>
@@ -50,12 +49,8 @@
 import axios from "axios";
 import _ from "lodash";
 import embed from "vega-embed";
-import explorer from "./Explorer.vue";
 
 export default {
-  components: {
-    explorer,
-  },
   data() {
     return {
       dataLoaded: false,
@@ -307,7 +302,7 @@ export default {
         this.$route.params.cdm +
         "/" +
         item.cdm_release_date.replaceAll("-", "") +
-        "/quality?tab=overview"
+        "/data_quality?tab=overview"
       );
     },
     getDataQualityResultsFailedRoute(item) {
@@ -316,7 +311,7 @@ export default {
         this.$route.params.cdm +
         "/" +
         item.cdm_release_date.replaceAll("-", "") +
-        "/quality?tab=results&failFilter=enabled"
+        "/data_quality?tab=results&failFilter=enabled"
       );
     },
   },

--- a/src/components/DataQualityHistory.vue
+++ b/src/components/DataQualityHistory.vue
@@ -298,7 +298,7 @@ export default {
     },
     getDataQualityOverviewRoute(item) {
       return (
-        "/_cdm/" +
+        "/cdm/" +
         this.$route.params.cdm +
         "/" +
         item.cdm_release_date.replaceAll("-", "") +
@@ -307,7 +307,7 @@ export default {
     },
     getDataQualityResultsFailedRoute(item) {
       return (
-        "/_cdm/" +
+        "/cdm/" +
         this.$route.params.cdm +
         "/" +
         item.cdm_release_date.replaceAll("-", "") +

--- a/src/components/DataQualityResults.vue
+++ b/src/components/DataQualityResults.vue
@@ -567,7 +567,7 @@ export default {
     //     path: "/_cdm/:cdm/:release/concept/:domain/:concept/summary",
     getConceptDrilldown: function (item) {
       return (
-        "/_cdm/" +
+        "/cdm/" +
         this.$route.params.cdm +
         "/" +
         this.$route.params.release +

--- a/src/components/DataQualityResults.vue
+++ b/src/components/DataQualityResults.vue
@@ -1,6 +1,5 @@
 <template>
   <v-responsive>
-    <explorer></explorer>
     <div v-if="componentFailed">
       <error v-bind:text="errorText" v-bind:details="errorDetails"></error>
     </div>
@@ -399,7 +398,6 @@ import { codemirror } from "vue-codemirror";
 import "codemirror/lib/codemirror.css";
 import "codemirror/mode/sql/sql";
 import "codemirror/theme/neat.css";
-import explorer from "./Explorer.vue";
 import infopanel from "./InfoPanel.vue";
 import error from "./Error.vue";
 import * as d3 from "d3-format";
@@ -549,7 +547,6 @@ export default {
   components: {
     error,
     codemirror,
-    explorer,
     infopanel,
   },
   watch: {

--- a/src/components/DeathReport.vue
+++ b/src/components/DeathReport.vue
@@ -3,7 +3,6 @@
     <div v-if="componentFailed">
       <error v-bind:text="errorText" v-bind:details="errorDetails"></error>
     </div>
-    <explorer></explorer>
     <v-container v-if="!componentFailed">
       <v-responsive min-width="900">
         <div class="text-uppercase text-h6">Death Report</div>
@@ -43,7 +42,6 @@
 import axios from "axios";
 import embed from "vega-embed";
 import error from "./Error.vue";
-import explorer from "./Explorer.vue";
 import * as d3 from "d3-time-format";
 import dataService from "../services/DataService";
 
@@ -250,7 +248,6 @@ export default {
   },
   components: {
     error,
-    explorer,
   },
   created() {
     this.load();

--- a/src/components/DomainContinuity.vue
+++ b/src/components/DomainContinuity.vue
@@ -1,7 +1,5 @@
 <template>
   <v-responsive min-width="900">
-    <explorer></explorer>
-
     <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
       <v-card-title>Domain Continuity</v-card-title>
       <div class="viz-container" id="viz-continuity"></div>
@@ -15,7 +13,6 @@
 <script>
 import embed from "vega-embed";
 import axios from "axios";
-import explorer from "./Explorer.vue";
 import InfoPanel from "./InfoPanel.vue";
 
 export default {
@@ -76,7 +73,6 @@ export default {
     };
   },
   components: {
-    explorer,
     InfoPanel,
   },
   created() {

--- a/src/components/DomainDensity.vue
+++ b/src/components/DomainDensity.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <explorer></explorer>
     <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
       <v-card-title>Domain Density</v-card-title>
       <div style="width: 80%" id="viz-overview"></div>
@@ -17,7 +16,6 @@
 import embed from "vega-embed";
 import axios from "axios";
 import * as d3Import from "d3-dsv";
-import explorer from "./Explorer.vue";
 
 export default {
   data() {
@@ -126,9 +124,6 @@ export default {
         ],
       },
     };
-  },
-  components: {
-    explorer,
   },
   watch: {
     $route() {

--- a/src/components/DomainTable.vue
+++ b/src/components/DomainTable.vue
@@ -305,7 +305,7 @@ export default {
         this.$route.params.cdm +
         "/" +
         this.$route.params.release +
-        "/quality";
+        "/data_quality";
 
       this.$router.push({
         path: qualitypath,

--- a/src/components/DomainTable.vue
+++ b/src/components/DomainTable.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <explorer v-if="dataLoaded || componentFailed"></explorer>
     <div v-if="componentFailed">
       <error v-bind:text="errorText" v-bind:details="errorDetails"></error>
     </div>
@@ -189,7 +188,6 @@
 import axios from "axios";
 import * as d3Import from "d3-dsv";
 import * as d3Format from "d3-format";
-import explorer from "./Explorer.vue";
 import error from "./Error.vue";
 import embed from "vega-embed";
 import InfoPanel from "./InfoPanel.vue";
@@ -329,11 +327,10 @@ export default {
         this.$route.params.cdm +
         "/" +
         this.$route.params.release +
-        "/concept/" +
+          "/" +
         this.$route.params.domain +
         "/" +
-        item.CONCEPT_ID +
-        "/summary"
+        item.CONCEPT_ID
       );
     },
     load() {
@@ -487,7 +484,6 @@ export default {
     this.load();
   },
   components: {
-    explorer,
     error,
     InfoPanel,
   },

--- a/src/components/DomainTable.vue
+++ b/src/components/DomainTable.vue
@@ -301,7 +301,7 @@ export default {
     },
     navigateToDataQuality: function () {
       var qualitypath =
-        "/_cdm/" +
+        "/cdm/" +
         this.$route.params.cdm +
         "/" +
         this.$route.params.release +
@@ -323,7 +323,7 @@ export default {
     },
     getReportRoute(item) {
       return (
-        "/_cdm/" +
+        "/cdm/" +
         this.$route.params.cdm +
         "/" +
         this.$route.params.release +

--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -99,7 +99,6 @@ import axios from "axios";
 export default {
   data() {
     return {
-      selectedSource: null,
       networkIndex: [],
       folders: [
         {
@@ -300,80 +299,55 @@ export default {
   },
 
   computed: {
+
     getFolder: function () {
-      let selectedFolderIndex;
-      for (let i = 0; i < this.folders.length; i++) {
-        if (this.$route.path.includes(this.folders[i].key)) {
-          return(this.folders[i])
-        }
-      }
-      return (
-          this.folders[selectedFolderIndex]
-      )
+      return this.folders.find(folder =>
+          this.$route.matched.some(route =>
+              route.name === folder.key));
     },
     getFilteredReports: function () {
-      return (
-          this.reports.filter(
-              (report) => report.folder === this.getFolder.name
-          )
-      )
+      return this.reports.filter((report) =>
+          report.folder === this.getFolder.name);
     },
     getSource: function () {
-      let selectedSourceIndex;
-      for (let i = 0; i < this.sources.length; i++) {
-        if (this.$route.path.includes(this.sources[i].cdm_source_key)) {
-          selectedSourceIndex = i;
-        }
-      }
-      return (
-          this.sources[selectedSourceIndex]
-      )
+      return this.sources.find(source =>
+          this.$route.params.cdm === source.cdm_source_key);
     },
-    getReleases: function() {
-      return(this.getSource.releases)
+    getReleases: function () {
+      return this.getSource.releases;
     },
     getSelectedRelease: function () {
-      let selectedReleaseIndex;
-      for (let i = 0; i < this.getReleases.length; i++) {
-        if (this.$route.path.includes(this.getReleases[i].release_id)) {
-          selectedReleaseIndex = i;
-        }
-      }
-      return (this.getReleases[selectedReleaseIndex])
+      return this.getReleases.find(release =>
+          this.$route.params.release === release.release_id)
     },
     getSelectedReport: function () {
-      let selectedReportIndex;
-      for(let i = 0; i < this.getFilteredReports.length; i++) {
-        if(this.$route.path.includes(this.getFilteredReports[i].domain ?
-            this.getFilteredReports[i].domain :
-            this.getFilteredReports[i].routeName))
-            selectedReportIndex = i
-      }
-      return (this.getFilteredReports[selectedReportIndex])
+      return this.getFilteredReports.find(report =>
+          report.domain ?
+              this.$route.params.domain === report.domain :
+              this.$route.matched.some(route => route.name === report.routeName)
+      )
     },
-    showConceptSelector: function() {
+    showConceptSelector: function () {
       return this.$route.params.concept;
     },
     showSourceSelector: function () {
       return (this.getFolder.key === "_datasource" ||
           this.getFolder.key === "_cdm");
-
     },
     showReleaseSelector: function () {
       return this.getFolder.key === "_cdm";
-
     },
   },
 
   methods: {
     changeSource(data) {
       this.$router.push({
-        params: {
-          ...this.$route.params,
-          cdm: data.cdm_source_key,
-          release: data.releases[0].release_id
-        }
-      }
+            params: {
+              ...this.$route.params,
+              cdm: data.cdm_source_key,
+              release: data.releases[0].release_id
+            }
+          }
       )
     },
     changeRelease(data) {
@@ -386,18 +360,22 @@ export default {
     },
     changeFolder(data) {
       this.$router.push({
-        path: `/${data.key}/${this.sources[0].cdm_source_key}/${this.sources[0].releases[0].release_id}`
+        name: data.key,
+        params: {
+          cdm: this.sources[0].cdm_source_key,
+          release: this.sources[0].releases[0].release_id
+        }
       })
     },
     changeReport(data) {
-        this.$router.push({
-          name: data.routeName,
-          params: {
-            ...this.$route.params,
-            domain: data.domain,
-            concept: ''
-          }
-        });
+      this.$router.push({
+        name: data.routeName,
+        params: {
+          ...this.$route.params,
+          domain: data.domain,
+          concept: ''
+        }
+      });
     },
   },
   name: "explorer",

--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -15,7 +15,7 @@
           class="mt-4"
           label="Report Category"
           @input="changeFolder"
-          :value="getFolder"
+          :value="getSelectedFolder"
           return-object
           prepend-icon="mdi-folder"
           auto-select-first
@@ -34,7 +34,7 @@
           class="mt-4"
           label="Data Source"
           @input="changeSource"
-          :value="getSource"
+          :value="getSelectedSource"
           return-object
           prepend-icon="mdi-database"
           auto-select-first
@@ -104,17 +104,17 @@ export default {
         {
           icon: "mdi-network",
           name: "Data Network",
-          key: "_network",
+          key: "network",
         },
         {
           icon: "mdi-database",
           name: "Data Source",
-          key: "_datasource",
+          key: "datasource",
         },
         {
           icon: "mdi-database-clock",
           name: "Data Source Release",
-          key: "_cdm",
+          key: "cdm",
         },
         /*
         {
@@ -126,13 +126,12 @@ export default {
         */
       ],
       sources: [],
-      filteredReports: [],
       reports: [
         {
           folder: "Data Source Release",
           icon: "mdi-sigma-lower",
           name: "Data Quality",
-          routeName: "data_quality"
+          routeName: "dataQuality"
         },
         {
           folder: "Data Source Release",
@@ -144,92 +143,92 @@ export default {
           folder: "Data Source Release",
           icon: "mdi-chart-line",
           name: "Data Density",
-          routeName: "data_density"
+          routeName: "dataDensity"
         },
         {
           folder: "Data Source Release",
           icon: "mdi-chart-line",
           name: "Observation Period",
-          routeName: "observation_period"
+          routeName: "observationPeriod"
         },
         {
           folder: "Data Source",
           name: "Data Quality History",
-          routeName: "data_quality_history"
+          routeName: "dataQualityHistory"
         },
         {
           folder: "Data Source",
           name: "Domain Continuity",
-          routeName: "domain_continuity"
+          routeName: "domainContinuity"
         },
         {
           folder: "Data Source Release",
           icon: "mdi-table",
           name: "Conditions",
-          routeName: "domain_table",
+          routeName: "domainTable",
           domain: "condition_occurrence"
         },
         {
           folder: "Data Source Release",
           icon: "mdi-table",
           name: "Condition Eras",
-          routeName: "domain_table",
+          routeName: "domainTable",
           domain: "condition_era"
         },
         {
           folder: "Data Source Release",
           icon: "mdi-table",
           name: "Drugs",
-          routeName: "domain_table",
+          routeName: "domainTable",
           domain: "drug_exposure"
         },
         {
           folder: "Data Source Release",
           icon: "mdi-table",
           name: "Drug Eras",
-          routeName: "domain_table",
+          routeName: "domainTable",
           domain: "drug_era"
         },
         {
           folder: "Data Source Release",
           icon: "mdi-table",
           name: "Visit Occurrence",
-          routeName: "domain_table",
+          routeName: "domainTable",
           domain: "visit_occurrence"
         },
         {
           folder: "Data Source Release",
           icon: "mdi-table",
           name: "Visit Detail",
-          routeName: "domain_table",
+          routeName: "domainTable",
           domain: "visit_detail"
         },
         {
           folder: "Data Source Release",
           icon: "mdi-table",
           name: "Measurements",
-          routeName: "domain_table",
+          routeName: "domainTable",
           domain: "measurement"
         },
         {
           folder: "Data Source Release",
           icon: "mdi-table",
           name: "Observations",
-          routeName: "domain_table",
+          routeName: "domainTable",
           domain: "observation"
         },
         {
           folder: "Data Source Release",
           icon: "mdi-table",
           name: "Procedures",
-          routeName: "domain_table",
+          routeName: "domainTable",
           domain: "procedure_occurrence"
         },
         {
           folder: "Data Source Release",
           icon: "mdi-table",
           name: "Device Exposures",
-          routeName: "domain_table",
+          routeName: "domainTable",
           domain: "device_exposure"
         },
         {
@@ -242,7 +241,7 @@ export default {
           folder: "Data Source Release",
           icon: "mdi-table",
           name: "Unmapped Source Codes",
-          routeName: "unmapped_source_codes"
+          routeName: "unmappedSourceCodes"
         },
         {
           folder: "Data Source Release",
@@ -266,7 +265,7 @@ export default {
           folder: "Data Network",
           icon: "mdi-sigma-lower",
           name: "Quality Assessment",
-          routeName: "network_data_quality"
+          routeName: "networkDataQuality"
         },
         {
           folder: "Data Network",
@@ -278,7 +277,7 @@ export default {
           folder: "Data Network",
           icon: "mdi-dna",
           name: "Data Strand Report",
-          routeName: "data_strand_report"
+          routeName: "dataStrandReport"
         },
       ],
     };
@@ -300,21 +299,21 @@ export default {
 
   computed: {
 
-    getFolder: function () {
+    getSelectedFolder: function () {
       return this.folders.find(folder =>
           this.$route.matched.some(route =>
               route.name === folder.key));
     },
     getFilteredReports: function () {
       return this.reports.filter((report) =>
-          report.folder === this.getFolder.name);
+          report.folder === this.getSelectedFolder.name);
     },
-    getSource: function () {
+    getSelectedSource: function () {
       return this.sources.find(source =>
           this.$route.params.cdm === source.cdm_source_key);
     },
     getReleases: function () {
-      return this.getSource.releases;
+      return this.getSelectedSource.releases;
     },
     getSelectedRelease: function () {
       return this.getReleases.find(release =>
@@ -331,11 +330,11 @@ export default {
       return this.$route.params.concept;
     },
     showSourceSelector: function () {
-      return (this.getFolder.key === "_datasource" ||
-          this.getFolder.key === "_cdm");
+      return (this.getSelectedFolder.key === "datasource" ||
+          this.getSelectedFolder.key === "cdm");
     },
     showReleaseSelector: function () {
-      return this.getFolder.key === "_cdm";
+      return this.getSelectedFolder.key === "cdm";
     },
   },
 

--- a/src/components/ExplorerWrapper.vue
+++ b/src/components/ExplorerWrapper.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <Explorer />
+    <router-view name="ExplorerWrapper" />
+  </div>
+</template>
+
+<script>
+import Explorer from "./Explorer";
+
+export default {
+  name: "ExplorerWrapper",
+  components: {
+    Explorer
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/Help.vue
+++ b/src/components/Help.vue
@@ -1,6 +1,5 @@
 <template>
   <div id="help">
-    <explorer></explorer>
     <markdown
       v-if="contentLoaded"
       :content="markdownContent"
@@ -10,7 +9,6 @@
 </template>
 <script>
 import markdown from "markdown-it-vue";
-import explorer from "./Explorer.vue";
 import axios from "axios";
 
 export default {
@@ -33,7 +31,6 @@ export default {
   props: {},
   components: {
     markdown,
-    explorer,
   },
 };
 </script>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -19,7 +19,7 @@
     </div>
     <v-card-actions>
       <v-layout justify-center>
-        <v-btn class="ma-2" dark color="primary" to="/_network/overview">
+        <v-btn class="ma-2" dark color="primary" to="/network/overview">
           <v-icon left>mdi-database</v-icon>Explore Data Sources
         </v-btn>
         <!--

--- a/src/components/MetadataReport.vue
+++ b/src/components/MetadataReport.vue
@@ -1,8 +1,5 @@
 <template>
   <div>
-    <explorer
-      v-if="metadataDataLoaded || cdmsourceDataLoaded || componentFailed"
-    ></explorer>
     <div v-if="componentFailed">
       <error v-bind:text="errorText" v-bind:details="errorDetails"></error>
     </div>
@@ -43,7 +40,6 @@
 <script>
 import axios from "axios";
 import * as d3 from "d3-dsv";
-import explorer from "./Explorer.vue";
 import error from "./Error.vue";
 
 export default {
@@ -119,7 +115,6 @@ export default {
     this.load();
   },
   components: {
-    explorer,
     error,
   },
   computed: {},

--- a/src/components/NetworkConceptReport.vue
+++ b/src/components/NetworkConceptReport.vue
@@ -5,7 +5,6 @@
     </div>
     <v-container v-if="!componentFailed">
       <v-responsive min-width="900">
-        <explorer></explorer>
         <v-layout class="ma-0 mb-6 text-uppercase text-h6"
           >{{ conceptName }} NETWORK REPORT</v-layout
         >
@@ -68,7 +67,6 @@ import axios from "axios";
 import embed from "vega-embed";
 import _ from "lodash";
 import error from "./Error.vue";
-import explorer from "./Explorer.vue";
 import * as d3Format from "d3-format";
 
 export default {
@@ -144,7 +142,6 @@ export default {
   },
   components: {
     error,
-    explorer,
   },
   created() {
     this.load();

--- a/src/components/NetworkConceptReport.vue
+++ b/src/components/NetworkConceptReport.vue
@@ -177,11 +177,11 @@ export default {
     navigateToDataQuality() {
       this.$router.push({
         path:
-          "/_cdm/" +
+          "/cdm/" +
           this.$route.params.cdm +
           "/" +
           this.$route.params.release +
-          "/quality?tab=results&conceptFailFilter=" +
+          "/data_quality?tab=results&conceptFailFilter=" +
           this.$route.params.concept,
       });
     },

--- a/src/components/NetworkDataQualitySummary.vue
+++ b/src/components/NetworkDataQualitySummary.vue
@@ -3,7 +3,6 @@
     <div v-if="componentFailed">
       <error v-bind:text="errorText" v-bind:details="errorDetails"></error>
     </div>
-    <explorer></explorer>
     <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
       <v-card-title>Network Data Quality Issues by Category</v-card-title>
       <div class="viz-container" id="viz-category"></div>
@@ -18,10 +17,8 @@
 <script>
 import axios from "axios";
 import * as d3 from "d3-dsv";
-import explorer from "./Explorer.vue";
 import error from "./Error.vue";
 import embed from "vega-embed";
-import _ from "lodash";
 
 export default {
   data() {
@@ -105,18 +102,6 @@ export default {
         vm.failureSummary = d3.csvParse(response.data);
         vm.componentFailed = false;
         vm.dataLoaded = true;
-
-        var mapped = _.map(vm.failureSummary, (r) => {
-          return { RELEASE_NAME: r.RELEASE_NAME, RELEASE_ID: r.RELEASE_ID };
-        });
-        console.log(
-          _.uniqWith(
-            mapped,
-            (a, b) =>
-              a.RELEASE_NAME == b.RELEASE_NAME && a.RELEASE_ID == b.RELEASE_ID
-          ).sort
-        );
-
         vm.specIssueStratificationByCategory.data = {
           values: vm.failureSummary,
         };
@@ -149,7 +134,6 @@ export default {
       });
   },
   components: {
-    explorer,
     error,
   },
   methods: {

--- a/src/components/NetworkDataQualitySummary.vue
+++ b/src/components/NetworkDataQualitySummary.vue
@@ -112,11 +112,11 @@ export default {
           (vega) => {
             vega.view.addSignalListener("select", (name, value) => {
               var routeUrl =
-                "/_cdm/" +
+                "/cdm/" +
                 value.CDM_SOURCE_ +
                 "/" +
                 value.cdm_release_key +
-                "/quality?tab=results&categoryFailFilter=" +
+                "/data_quality?tab=results&categoryFailFilter=" +
                 value.c;
               console.log(routeUrl);
               console.log(value);

--- a/src/components/NetworkDatastrandReport.vue
+++ b/src/components/NetworkDatastrandReport.vue
@@ -1,7 +1,5 @@
 <template>
   <v-responsive min-width="900">
-    <explorer></explorer>
-
     <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
       <v-card-title>Data Strands</v-card-title>
       <div class="viz-container" id="viz-datastrand"></div>
@@ -19,7 +17,6 @@
 <script>
 import embed from "vega-embed";
 import axios from "axios";
-import explorer from "./Explorer.vue";
 import infopanel from "./InfoPanel.vue";
 import * as d3 from "d3-dsv";
 
@@ -181,7 +178,6 @@ export default {
     };
   },
   components: {
-    explorer,
     infopanel,
   },
   created() {

--- a/src/components/NetworkDatastrandReport.vue
+++ b/src/components/NetworkDatastrandReport.vue
@@ -230,7 +230,7 @@ export default {
                 result.view.addSignalListener("selectDomain", (name, value) => {
                   var domainKey = value.domain.toLowerCase().replace(" ", "_");
                   var routeUrl =
-                    "/_cdm/" +
+                    "/cdm/" +
                     value.cdm_source_key +
                     "/" +
                     value.cdm_release_key +

--- a/src/components/NetworkOverview.vue
+++ b/src/components/NetworkOverview.vue
@@ -131,7 +131,7 @@ export default {
     displayPersonReport: function (source) {
       this.$router.push({
         path:
-          "/_cdm/" +
+          "/cdm/" +
           source.cdm_source_key +
           "/" +
           source.releases[0].release_id +
@@ -140,13 +140,13 @@ export default {
     },
     navigateToDataSourceHistory(datasource) {
       this.$router.push({
-        path: "/_datasource/" + datasource.cdm_source_key + "/quality-history",
+        path: "/datasource/" + datasource.cdm_source_key + "/data_quality_history",
       });
     },
     displayDetails: function (source) {
       this.$router.push({
         path:
-          "/_cdm/" +
+          "/cdm/" +
           source.cdm_source_key +
           "/" +
           source.releases[0].release_id +

--- a/src/components/NetworkOverview.vue
+++ b/src/components/NetworkOverview.vue
@@ -1,6 +1,5 @@
 <template>
   <div id="network-data-quality-overview" class="pa-4">
-    <explorer></explorer>
     <error
       v-if="!indexAvailable"
       :text="errorText"
@@ -96,7 +95,6 @@
 <script>
 import axios from "axios";
 import error from "./Error.vue";
-import explorer from "./Explorer.vue";
 import infopanel from "./InfoPanel.vue";
 import * as d3 from "d3-format";
 
@@ -124,7 +122,6 @@ export default {
   },
   components: {
     error,
-    explorer,
     infopanel,
   },
   methods: {
@@ -153,7 +150,7 @@ export default {
           source.cdm_source_key +
           "/" +
           source.releases[0].release_id +
-          "/quality",
+          "/data_quality",
       });
     },
   },

--- a/src/components/NetworkPopulationReport.vue
+++ b/src/components/NetworkPopulationReport.vue
@@ -5,7 +5,6 @@
     </div>
     <v-container v-if="!componentFailed">
       <v-responsive min-width="900">
-        <explorer></explorer>
         <v-layout class="ma-0 mb-6 text-uppercase text-h6"
           >{{ conceptName }} NETWORK POPULATION OVERVIEW</v-layout
         >
@@ -27,7 +26,6 @@ import axios from "axios";
 import embed from "vega-embed";
 /*import _ from "lodash";*/
 import error from "./Error.vue";
-import explorer from "./Explorer.vue";
 import * as d3Format from "d3-format";
 
 export default {
@@ -124,7 +122,6 @@ export default {
   },
   components: {
     error,
-    explorer,
   },
   created() {
     this.load();

--- a/src/components/NetworkPopulationReport.vue
+++ b/src/components/NetworkPopulationReport.vue
@@ -136,11 +136,11 @@ export default {
     navigateToDataQuality() {
       this.$router.push({
         path:
-          "/_cdm/" +
+          "/cdm/" +
           this.$route.params.cdm +
           "/" +
           this.$route.params.release +
-          "/quality?tab=results&conceptFailFilter=" +
+          "/data_quality?tab=results&conceptFailFilter=" +
           this.$route.params.concept,
       });
     },

--- a/src/components/ObservationPeriodReport.vue
+++ b/src/components/ObservationPeriodReport.vue
@@ -3,7 +3,6 @@
     <div v-if="componentFailed">
       <error v-bind:text="errorText" v-bind:details="errorDetails"></error>
     </div>
-    <explorer></explorer>
     <v-container v-if="!componentFailed">
       <v-responsive min-width="900">
         <div class="text-uppercase text-h6">Observation Period Report</div>
@@ -40,7 +39,6 @@
 import axios from "axios";
 import embed from "vega-embed";
 import error from "./Error.vue";
-import explorer from "./Explorer.vue";
 import * as d3 from "d3-time-format";
 
 export default {
@@ -306,7 +304,6 @@ export default {
   },
   components: {
     error,
-    explorer,
   },
   watch: {
     $route() {

--- a/src/components/PerformanceTable.vue
+++ b/src/components/PerformanceTable.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <explorer v-if="dataLoaded || componentFailed"></explorer>
     <div v-if="componentFailed">
       <error v-bind:text="errorText" v-bind:details="errorDetails"></error>
     </div>
@@ -74,7 +73,6 @@
 <script>
 import axios from "axios";
 import * as d3 from "d3-dsv";
-import explorer from "./Explorer.vue";
 import error from "./Error.vue";
 
 export default {
@@ -174,7 +172,6 @@ export default {
     );
   },
   components: {
-    explorer,
     error,
   },
   computed: {

--- a/src/components/PersonReport.vue
+++ b/src/components/PersonReport.vue
@@ -3,7 +3,6 @@
     <div v-if="componentFailed">
       <error v-bind:text="errorText" v-bind:details="errorDetails"></error>
     </div>
-    <explorer></explorer>
     <v-container v-if="!componentFailed">
       <v-responsive min-width="900">
         <div class="text-uppercase text-h6">Person Report</div>
@@ -78,7 +77,6 @@
 import axios from "axios";
 import embed from "vega-embed";
 import error from "./Error.vue";
-import explorer from "./Explorer.vue";
 import * as d3 from "d3-time-format";
 import * as d3Format from "d3-format";
 
@@ -244,7 +242,6 @@ export default {
   },
   components: {
     error,
-    explorer,
   },
   created() {
     this.load();

--- a/src/components/SourceConceptReport.vue
+++ b/src/components/SourceConceptReport.vue
@@ -5,7 +5,6 @@
     </div>
     <v-container v-if="!componentFailed">
       <v-responsive min-width="900">
-        <explorer></explorer>
         <v-layout class="ma-0 mb-1 text-uppercase text-h6"
           >Data Source Release Comparison
         </v-layout>
@@ -49,7 +48,6 @@ import axios from "axios";
 import embed from "vega-embed";
 import {flatten, sumBy} from "lodash";
 import error from "./Error.vue";
-import explorer from "./Explorer.vue";
 import * as d3Format from "d3-format";
 import * as d3 from "d3-time-format";
 
@@ -144,7 +142,6 @@ export default {
   },
   components: {
     error,
-    explorer,
   },
   created() {
     this.load();

--- a/src/components/UnmappedSourceCodes.vue
+++ b/src/components/UnmappedSourceCodes.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <explorer v-if="dataLoaded || componentFailed"></explorer>
     <div v-if="componentFailed">
       <error v-bind:text="errorText" v-bind:details="errorDetails"></error>
     </div>
@@ -75,7 +74,6 @@
 <script>
 import axios from "axios";
 import * as d3 from "d3-dsv";
-import explorer from "./Explorer.vue";
 import error from "./Error.vue";
 
 export default {
@@ -177,7 +175,6 @@ export default {
     );
   },
   components: {
-    explorer,
     error,
   },
   computed: {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -39,8 +39,9 @@ const routes = [
 
   {
     path: "/_network",
-    name: "network",
+    name: "_network",
     components: {main: ExplorerWrapper},
+    redirect: {name: "overview"},
     children: [
       {
         path: "network_data_quality",
@@ -67,17 +68,14 @@ const routes = [
         name: "concept",
         components: {ExplorerWrapper: networkConceptReport}
       },
-      {
-        path: "*",
-        name: "overview",
-        redirect: "overview"
-      }
     ]
   },
 
   {
     path: "/_cdm/:cdm/:release",
+    name: "_cdm",
     components: {main: ExplorerWrapper},
+    redirect: {name: "person"},
     children: [
       {
         path: "observation_period",
@@ -128,16 +126,13 @@ const routes = [
         path: ":domain/:concept/",
         components: { ExplorerWrapper: conceptReport },
       },
-      {
-        path: "/",
-        name: "person",
-        redirect: "person"
-      },
     ]
   },
   {
     path: "/_datasource/:cdm",
+    name: "_datasource",
     components: {main: ExplorerWrapper},
+    redirect: {name: "data_quality_history"},
     children: [
       {
         path: "data_quality_history",
@@ -151,13 +146,8 @@ const routes = [
       },
       {
         path: ":domain/:concept/overlay",
-        name: "Source Concept Overlay",
+        name: "source_concept_overlay",
         components: {ExplorerWrapper: sourceConceptReport}
-      },
-      {
-        path: "*",
-        name: "Quality history",
-        redirect: "data_quality_history"
       },
     ]
   },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -38,19 +38,19 @@ const routes = [
   { path: "/help", components: { main: help } },
 
   {
-    path: "/_network",
-    name: "_network",
+    path: "/network",
+    name: "network",
     components: {main: ExplorerWrapper},
     redirect: {name: "overview"},
     children: [
       {
         path: "network_data_quality",
-        name: "network_data_quality",
+        name: "networkDataQuality",
         components: {ExplorerWrapper: networkDataQualitySummary}
       },
       {
         path: "data_strand_report",
-        name: "data_strand_report",
+        name: "dataStrandReport",
         components: {ExplorerWrapper: networkDatastrandReport}
       },
       {
@@ -72,14 +72,14 @@ const routes = [
   },
 
   {
-    path: "/_cdm/:cdm/:release",
-    name: "_cdm",
+    path: "/cdm/:cdm/:release",
+    name: "cdm",
     components: {main: ExplorerWrapper},
     redirect: {name: "person"},
     children: [
       {
         path: "observation_period",
-        name: "observation_period",
+        name: "observationPeriod",
         components: {ExplorerWrapper: observationPeriodReport}
       },
       {
@@ -94,17 +94,17 @@ const routes = [
       },
       {
         path: "data_quality",
-        name: "data_quality",
+        name: "dataQuality",
         components: {ExplorerWrapper: dataQualityResults}
       },
       {
         path: "data_density",
-        name: "data_density",
+        name: "dataDensity",
         components: {ExplorerWrapper: domainDensity}
       },
       {
         path: "unmapped_source_codes",
-        name: "unmapped_source_codes",
+        name: "unmappedSourceCodes",
         components: {ExplorerWrapper: unmappedSourceCodes}
       },
       {
@@ -120,7 +120,7 @@ const routes = [
       {
         path: ":domain",
         components: {ExplorerWrapper: domainTable},
-        name: "domain_table",
+        name: "domainTable",
       },
       {
         path: ":domain/:concept/",
@@ -129,24 +129,24 @@ const routes = [
     ]
   },
   {
-    path: "/_datasource/:cdm",
-    name: "_datasource",
+    path: "/datasource/:cdm",
+    name: "datasource",
     components: {main: ExplorerWrapper},
-    redirect: {name: "data_quality_history"},
+    redirect: {name: "dataQualityHistory"},
     children: [
       {
         path: "data_quality_history",
-        name: "data_quality_history",
+        name: "dataQualityHistory",
         components: {ExplorerWrapper: dataQualityHistory}
       },
       {
         path: "domain_continuity",
-        name: "domain_continuity",
+        name: "domainContinuity",
         components: {ExplorerWrapper: domainContinuity}
       },
       {
         path: ":domain/:concept/overlay",
-        name: "source_concept_overlay",
+        name: "sourceConceptOverlay",
         components: {ExplorerWrapper: sourceConceptReport}
       },
     ]

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -23,6 +23,7 @@ import metadataReport from "../components/MetadataReport.vue";
 import home from "../components/Home.vue";
 import article from "../components/Article.vue";
 import unmappedSourceCodes from "../components/UnmappedSourceCodes.vue";
+import ExplorerWrapper from "../components/ExplorerWrapper";
 
 Vue.use(VueRouter);
 
@@ -35,72 +36,132 @@ const routes = [
   },
   { path: "/home", components: { main: home } },
   { path: "/help", components: { main: help } },
-  { path: "/_network/overview", components: { main: networkOverview } },
+
   {
-    path: "/_network/concept/:domain/:concept/summary",
-    components: { main: networkConceptReport },
+    path: "/_network",
+    name: "network",
+    components: {main: ExplorerWrapper},
+    children: [
+      {
+        path: "network_data_quality",
+        name: "network_data_quality",
+        components: {ExplorerWrapper: networkDataQualitySummary}
+      },
+      {
+        path: "data_strand_report",
+        name: "data_strand_report",
+        components: {ExplorerWrapper: networkDatastrandReport}
+      },
+      {
+        path: "population",
+        name: "population",
+        components: {ExplorerWrapper: networkPopulationReport}
+      },
+      {
+        path: "overview",
+        name: "overview",
+        components: {ExplorerWrapper: networkOverview}
+      },
+      {
+        path: "concept/:domain/:concept/summary",
+        name: "concept",
+        components: {ExplorerWrapper: networkConceptReport}
+      },
+      {
+        path: "*",
+        name: "overview",
+        redirect: "overview"
+      }
+    ]
+  },
+
+  {
+    path: "/_cdm/:cdm/:release",
+    components: {main: ExplorerWrapper},
+    children: [
+      {
+        path: "observation_period",
+        name: "observation_period",
+        components: {ExplorerWrapper: observationPeriodReport}
+      },
+      {
+        path: "metadata",
+        name: "metadata",
+        components: {ExplorerWrapper: metadataReport}
+      },
+      {
+        path: "death",
+        name: "death",
+        components: {ExplorerWrapper: deathReport}
+      },
+      {
+        path: "data_quality",
+        name: "data_quality",
+        components: {ExplorerWrapper: dataQualityResults}
+      },
+      {
+        path: "data_density",
+        name: "data_density",
+        components: {ExplorerWrapper: domainDensity}
+      },
+      {
+        path: "unmapped_source_codes",
+        name: "unmapped_source_codes",
+        components: {ExplorerWrapper: unmappedSourceCodes}
+      },
+      {
+        path: "performance",
+        name: "performance",
+        components: {ExplorerWrapper: performanceReport}
+      },
+      {
+        path: "person",
+        name: "person",
+        components: {ExplorerWrapper: personReport}
+      },
+      {
+        path: ":domain",
+        components: {ExplorerWrapper: domainTable},
+        name: "domain_table",
+      },
+      {
+        path: ":domain/:concept/",
+        components: { ExplorerWrapper: conceptReport },
+      },
+      {
+        path: "/",
+        name: "person",
+        redirect: "person"
+      },
+    ]
   },
   {
-    path: "/_network/dataquality",
-    components: { main: networkDataQualitySummary },
+    path: "/_datasource/:cdm",
+    components: {main: ExplorerWrapper},
+    children: [
+      {
+        path: "data_quality_history",
+        name: "data_quality_history",
+        components: {ExplorerWrapper: dataQualityHistory}
+      },
+      {
+        path: "domain_continuity",
+        name: "domain_continuity",
+        components: {ExplorerWrapper: domainContinuity}
+      },
+      {
+        path: ":domain/:concept/overlay",
+        name: "Source Concept Overlay",
+        components: {ExplorerWrapper: sourceConceptReport}
+      },
+      {
+        path: "*",
+        name: "Quality history",
+        redirect: "data_quality_history"
+      },
+    ]
   },
-  {
-    path: "/_network/datastrand",
-    components: { main: networkDatastrandReport },
-  },
-  {
-    path: "/_network/population",
-    components: { main: networkPopulationReport   },
-  },
-  {
-    path: "/_cdm/:cdm/:release/domain/:domain/summary",
-    components: { main: domainTable },
-  },
-  {
-    path: "/_cdm/:cdm/:release/observationperiod",
-    components: { main: observationPeriodReport },
-  },
-  {
-    path: "/_cdm/:cdm/:release/metadata",
-    components: { main: metadataReport },
-  },
-  {
-    path: "/_cdm/:cdm/:release/death",
-    components: { main: deathReport },
-  },
-  {
-    path: "/_cdm/:cdm/:release/quality/",
-    components: { main: dataQualityResults },
-  },
-  { path: "/_cdm/:cdm/:release/density/", components: { main: domainDensity } },
-  {
-    path: "/_cdm/:cdm/:release/unmapped/",
-    components: { main: unmappedSourceCodes },
-  },
-  {
-    path: "/_cdm/:cdm/:release/performance/",
-    components: { main: performanceReport },
-  },
-  {
-    path: "/_cdm/:cdm/:release/person/",
-    components: { main: personReport },
-  },
-  {
-    path: "/_datasource/:cdm/quality-history",
-    components: { main: dataQualityHistory },
-  },
-  {
-    path: "/_datasource/:cdm/concept/:domain/:concept/overlay",
-    components: {main: sourceConceptReport}
-  },
-  {
-    path: "/_datasource/:cdm/domain-continuity",
-    components: { main: domainContinuity },
-  },
-  {
-    path: "/_cdm/:cdm/:release/concept/:domain/:concept/summary",
-    components: { main: conceptReport },
-  },
+
   {
     path: "/publication/article",
     components: { main: article },


### PR DESCRIPTION
Closes https://github.com/OHDSI/Ares/issues/8

Changelist:

1. Explorer moved to its wrapper component, so it's now rendered only once

2. Added concept report indicator (only if a concept is opened)

3. Fixed the issue in question. Now changing both source and release should reload the concept report.

4. Added default routes for category changes

5. The Explorer component has been rewritten to utilize computed properties. The load function has been removed.

6. Router has been rewritten to utilize children for better visual structure.

7. Changed the router paths to better reflect the state of explorer

8. Some smaller tweaks here and there.