### PR TITLE
Explorer throws error when navigating directly to report

### DIFF
--- a/src/components/Explorer.vue
+++ b/src/components/Explorer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="explorer" class="pa-2">
+  <div v-if="dataLoaded" id="explorer" class="pa-2">
     <v-row>
       <v-col cols="1">
         <v-btn to="/home" icon large class="mb-8">
@@ -100,6 +100,7 @@ export default {
   data() {
     return {
       networkIndex: [],
+      dataLoaded: false,
       folders: [
         {
           icon: "mdi-network",
@@ -290,6 +291,7 @@ export default {
         this.networkIndex = response.data.dataQualityRecords;
         this.sources = response.data.sources;
         this.folder = response.data.folder
+        this.dataLoaded = true
       })
       .catch((err) => {
         console.log("explorer failed to load network index");
@@ -298,7 +300,6 @@ export default {
   },
 
   computed: {
-
     getSelectedFolder: function () {
       return this.folders.find(folder =>
           this.$route.matched.some(route =>


### PR DESCRIPTION
Closes https://github.com/OHDSI/Ares/issues/53

The problem was that the computed values were used before the data was loaded. The component is now rendered only after the data is loaded which should resolve the error.