### PR TITLE
Add tooltip and resize to measurement record count proportion chart

### DIFF
--- a/src/components/ConceptReport.vue
+++ b/src/components/ConceptReport.vue
@@ -8,7 +8,7 @@
       <v-responsive min-width="900">
         <v-layout class="ma-0 mb-6 d-flex justify-md-space-between">
           <h2 class="text-uppercase">
-            {{conceptName}}
+            {{ conceptName }}
           </h2>
           <ReturnButton />
         </v-layout>
@@ -508,52 +508,120 @@ export default {
       },
       specRecordProportionByAgeSexYear: {
         $schema: "https://vega.github.io/schema/vega-lite/v5.json",
-        width: 60,
-        height: 150,
         data: {},
-        mark: "line",
-        encoding: {
-          x: {
-            field: "X_CALENDAR_YEAR",
-            type: "quantitative",
-            title: "",
-            axis: {
-              format: "d",
-            },
-          },
-          y: {
-            field: "Y_PREVALENCE_1000PP",
-            type: "quantitative",
-            title: "",
-          },
-          color: {
-            title: "Sex",
-            field: "SERIES_NAME",
-            type: "nominal",
-            legend: {
-              orient: "right",
-            },
-          },
-          facet: {
+        facet: {
+          row: {
             field: "TRELLIS_NAME",
-            type: "nominal",
-            title: null,
-            sort: { field: "trellisOrder" },
-            rows: 1,
-            spacing: 20,
-            header: {
-              title: "Age Deciles",
-              labelOrient: "top",
-              labelAnchor: "start",
-              labelFontSize: 10,
-              labelPadding: 5,
-            },
+            title: "Age Deciles",
           },
+          field: "TRELLIS_NAME",
+          type: "nominal",
+          title: null,
+          sort: { field: "trellisOrder" },
+          rows: 1,
+          spacing: 20,
+        },
+        spec: {
+          width: "container",
+          height: 150,
+          encoding: {
+            x: {
+              field: "X_CALENDAR_YEAR",
+              type: "quantitative",
+              title: "",
+              axis: {
+                format: "d",
+              },
+            },
+            y: {
+              field: "Y_PREVALENCE_1000PP",
+              type: "quantitative",
+              title: "",
+            },
+            color: {
+              title: "Sex",
+              field: "SERIES_NAME",
+              type: "nominal",
+              legend: {
+                orient: "right",
+              },
+            },
+            tooltip: [
+              { field: "X_CALENDAR_YEAR", title: "Year" },
+              {
+                field: "Y_PREVALENCE_1000PP",
+                title: "Record Proportion per 1000",
+              },
+              { field: "TRELLIS_NAME", title: "Age Decile" },
+            ],
+          },
+          layer: [
+            {
+              mark: { type: "line", interpolate: "linear" },
+              params: [
+                {
+                  name: "source",
+                  select: { type: "point", fields: ["SERIES_NAME"] },
+                  bind: "legend",
+                },
+              ],
+              encoding: {
+                opacity: {
+                  condition: { param: "source", value: 1 },
+                  value: 0.2,
+                },
+              },
+            },
+            {
+              selection: {
+                dataSource: {
+                  type: "multi",
+                  fields: ["SERIES_NAME"],
+                  bind: "legend",
+                },
+                x: {
+                  type: "single",
+                  on: "mousemove",
+                  encodings: ["x"],
+                  nearest: true,
+                },
+              },
+              transform: [
+                {
+                  filter: { selection: "dataSource" },
+                },
+              ],
+              mark: { type: "point", tooltip: true },
+            },
+            {
+              transform: [
+                {
+                  filter: {
+                    and: ["x.X_CALENDAR_YEAR", { selection: "x" }],
+                  },
+                },
+                { filter: { selection: "dataSource" } },
+              ],
+              layer: [
+                {
+                  mark: "rule",
+                  encoding: {
+                    y: {
+                      height: 1,
+                    },
+                    color: {
+                      value: "black",
+                    },
+                  },
+                },
+              ],
+            },
+          ],
         },
       },
       specMeasurementValueDistribution: {
         $schema: "https://vega.github.io/schema/vega-lite/v5.json",
-        height: {"step": "20"},
+        height: { step: "20" },
         width: "container",
         data: {},
         encoding: { y: { field: "CATEGORY", type: "nominal", title: null } },

--- a/src/components/ConceptReport.vue
+++ b/src/components/ConceptReport.vue
@@ -510,16 +510,16 @@ export default {
         $schema: "https://vega.github.io/schema/vega-lite/v5.json",
         data: {},
         autosize: { resize: true },
-        spacing: 5,
+        spacing: 10,
         facet: {
           row: {
             field: "TRELLIS_NAME",
             title: "Age Deciles",
+            sort: { field: "trellisOrder" },
           },
           field: "TRELLIS_NAME",
           type: "nominal",
           title: null,
-          sort: { field: "trellisOrder" },
         },
         spec: {
           width: "container",

--- a/src/components/ConceptReport.vue
+++ b/src/components/ConceptReport.vue
@@ -509,6 +509,8 @@ export default {
       specRecordProportionByAgeSexYear: {
         $schema: "https://vega.github.io/schema/vega-lite/v5.json",
         data: {},
+        autosize: { resize: true },
+        spacing: 5,
         facet: {
           row: {
             field: "TRELLIS_NAME",
@@ -518,12 +520,10 @@ export default {
           type: "nominal",
           title: null,
           sort: { field: "trellisOrder" },
-          rows: 1,
-          spacing: 20,
         },
         spec: {
           width: "container",
-          height: 150,
+          height: 30,
           encoding: {
             x: {
               field: "X_CALENDAR_YEAR",
@@ -544,6 +544,7 @@ export default {
               type: "nominal",
               legend: {
                 orient: "right",
+                offset: 5,
               },
             },
             tooltip: [

--- a/src/components/DeathReport.vue
+++ b/src/components/DeathReport.vue
@@ -146,17 +146,17 @@ export default {
       specRecordProportionByAgeSexYear: {
         $schema: "https://vega.github.io/schema/vega-lite/v5.json",
         data: {},
-        spacing: 5,
+        spacing: 10,
         autosize: { resize: true },
         facet: {
           row: {
             field: "TRELLIS_NAME",
             title: "Age Deciles",
+            sort: { field: "trellisOrder" },
           },
           field: "TRELLIS_NAME",
           type: "nominal",
           title: null,
-          sort: { field: "trellisOrder" },
         },
         spec: {
           width: "container",

--- a/src/components/DeathReport.vue
+++ b/src/components/DeathReport.vue
@@ -146,6 +146,8 @@ export default {
       specRecordProportionByAgeSexYear: {
         $schema: "https://vega.github.io/schema/vega-lite/v5.json",
         data: {},
+        spacing: 5,
+        autosize: { resize: true },
         facet: {
           row: {
             field: "TRELLIS_NAME",
@@ -155,12 +157,10 @@ export default {
           type: "nominal",
           title: null,
           sort: { field: "trellisOrder" },
-          rows: 1,
-          spacing: 20,
         },
         spec: {
           width: "container",
-          height: 150,
+          height: 30,
           encoding: {
             x: {
               field: "X_CALENDAR_YEAR",
@@ -181,6 +181,7 @@ export default {
               type: "nominal",
               legend: {
                 orient: "right",
+                offset: 5,
               },
             },
             tooltip: [

--- a/src/components/DeathReport.vue
+++ b/src/components/DeathReport.vue
@@ -145,47 +145,115 @@ export default {
       },
       specRecordProportionByAgeSexYear: {
         $schema: "https://vega.github.io/schema/vega-lite/v5.json",
-        width: 60,
-        height: 150,
         data: {},
-        mark: "line",
-        encoding: {
-          x: {
-            field: "X_CALENDAR_YEAR",
-            type: "quantitative",
-            title: "",
-            axis: {
-              format: "d",
-            },
-          },
-          y: {
-            field: "Y_PREVALENCE_1000PP",
-            type: "quantitative",
-            title: "",
-          },
-          color: {
-            title: "Sex",
-            field: "SERIES_NAME",
-            type: "nominal",
-            legend: {
-              orient: "right",
-            },
-          },
-          facet: {
+        facet: {
+          row: {
             field: "TRELLIS_NAME",
-            type: "nominal",
-            title: null,
-            sort: {"field": "trellisOrder"},
-            rows: 1,
-            spacing: 5,
-            header: {
-              title: "Age Deciles",
-              labelOrient: "top",
-              labelAnchor: "start",
-              labelFontSize: 10,
-              labelPadding: 5,
-            },
+            title: "Age Deciles",
           },
+          field: "TRELLIS_NAME",
+          type: "nominal",
+          title: null,
+          sort: { field: "trellisOrder" },
+          rows: 1,
+          spacing: 20,
+        },
+        spec: {
+          width: "container",
+          height: 150,
+          encoding: {
+            x: {
+              field: "X_CALENDAR_YEAR",
+              type: "quantitative",
+              title: "",
+              axis: {
+                format: "d",
+              },
+            },
+            y: {
+              field: "Y_PREVALENCE_1000PP",
+              type: "quantitative",
+              title: "",
+            },
+            color: {
+              title: "Sex",
+              field: "SERIES_NAME",
+              type: "nominal",
+              legend: {
+                orient: "right",
+              },
+            },
+            tooltip: [
+              { field: "X_CALENDAR_YEAR", title: "Year" },
+              {
+                field: "Y_PREVALENCE_1000PP",
+                title: "Record Proportion per 1000",
+              },
+              { field: "TRELLIS_NAME", title: "Age Decile" },
+            ],
+          },
+          layer: [
+            {
+              mark: { type: "line", interpolate: "linear" },
+              params: [
+                {
+                  name: "source",
+                  select: { type: "point", fields: ["SERIES_NAME"] },
+                  bind: "legend",
+                },
+              ],
+              encoding: {
+                opacity: {
+                  condition: { param: "source", value: 1 },
+                  value: 0.2,
+                },
+              },
+            },
+            {
+              selection: {
+                dataSource: {
+                  type: "multi",
+                  fields: ["SERIES_NAME"],
+                  bind: "legend",
+                },
+                x: {
+                  type: "single",
+                  on: "mousemove",
+                  encodings: ["x"],
+                  nearest: true,
+                },
+              },
+              transform: [
+                {
+                  filter: { selection: "dataSource" },
+                },
+              ],
+              mark: { type: "point", tooltip: true },
+            },
+            {
+              transform: [
+                {
+                  filter: {
+                    and: ["x.X_CALENDAR_YEAR", { selection: "x" }],
+                  },
+                },
+                { filter: { selection: "dataSource" } },
+              ],
+              layer: [
+                {
+                  mark: "rule",
+                  encoding: {
+                    y: {
+                      height: 1,
+                    },
+                    color: {
+                      value: "black",
+                    },
+                  },
+                },
+              ],
+            },
+          ],
         },
       },
       specRecordProportionByMonth: {
@@ -283,7 +351,12 @@ export default {
           embed("#viz-deathbytype", vm.specDeathByType);
 
           vm.specRecordProportionByAgeSexYear.data = {
-            values: dataService.sortByRange(vm.deathData.PREVALENCE_BY_GENDER_AGE_YEAR, "ascending", "TRELLIS_NAME", "trellisOrder")
+            values: dataService.sortByRange(
+              vm.deathData.PREVALENCE_BY_GENDER_AGE_YEAR,
+              "ascending",
+              "TRELLIS_NAME",
+              "trellisOrder"
+            ),
           };
 
           embed(


### PR DESCRIPTION
Closes https://github.com/OHDSI/Ares/issues/39

Added interactivity and tooltip to the report. 

The ruler will change its position in all of the reports at the same time, the tooltip will show only for the one in focus. 

Legend can filter out data depending on what's currently in focus. 

The charts are now aligned vertically and stretched to container width.