### PR TITLE
Clear table / return to loading status on cards when toggling data source selection

### DIFF
--- a/src/components/ConceptReport.vue
+++ b/src/components/ConceptReport.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-if="componentFailed">
-      <error v-bind:text="errorText" v-bind:details="errorDetails"></error>
+      <error :text="errorText" :details="errorDetails"></error>
       <ReturnButton block />
     </div>
     <v-container v-if="!componentFailed">
@@ -71,8 +71,8 @@
           ></v-row
         >
         <v-card
-          :loading="!dataLoaded"
           v-if="hasMeasurementValueDistribution"
+          :loading="!dataLoaded"
           elevation="10"
           class="ma-4 pa-2"
         >
@@ -84,8 +84,8 @@
             >
           </v-layout>
           <div
-            class="viz-container"
             id="viz-measurementvaluedistribution"
+            class="viz-container"
           ></div>
           <v-card-text>
             <v-layout>
@@ -101,13 +101,13 @@
           </v-card-text>
         </v-card>
         <v-card
-          :loading="!dataLoaded"
           v-if="hasAgeAtFirstDiagnosis"
+          :loading="!dataLoaded"
           elevation="10"
           class="ma-4 pa-2"
         >
           <v-card-title>Age at First Diagnosis</v-card-title>
-          <div class="viz-container" id="viz-ageatfirstdiagnosis"></div>
+          <div id="viz-ageatfirstdiagnosis" class="viz-container"></div>
           <v-card-text>
             <router-link to="/help">
               <v-icon small color="info" left> mdi-help-circle</v-icon>Learn how
@@ -116,13 +116,13 @@
           </v-card-text>
         </v-card>
         <v-card
-          :loading="!dataLoaded"
           v-if="hasAgeAtFirstExposure"
+          :loading="!dataLoaded"
           elevation="10"
           class="ma-4 pa-2"
         >
           <v-card-title>Age at First Exposure</v-card-title>
-          <div class="viz-container" id="viz-ageatfirstexposure"></div>
+          <div id="viz-ageatfirstexposure" class="viz-container"></div>
           <v-card-text>
             <router-link to="/help">
               <v-icon small color="info" left> mdi-help-circle</v-icon>Learn how
@@ -132,23 +132,23 @@
         </v-card>
 
         <v-card
-          :loading="!dataLoaded"
           v-if="hasLengthOfEra"
+          :loading="!dataLoaded"
           elevation="10"
           class="ma-4 pa-2"
         >
           <v-card-title>Length of Era</v-card-title>
-          <div class="viz-container" id="viz-lengthofera"></div>
+          <div id="viz-lengthofera" class="viz-container"></div>
         </v-card>
 
         <v-card
-          :loading="!dataLoaded"
           v-if="hasConditionsByType"
+          :loading="!dataLoaded"
           elevation="10"
           class="ma-4 pa-2"
         >
           <v-card-title>Conditions by Type</v-card-title>
-          <div class="viz-container" id="viz-conditionsbytype"></div>
+          <div id="viz-conditionsbytype" class="viz-container"></div>
           <v-card-text>
             <a
               href="https://ohdsi.github.io/CommonDataModel/cdm531.html#CONDITION_OCCURRENCE"
@@ -161,13 +161,13 @@
         </v-card>
 
         <v-card
-          :loading="!dataLoaded"
           v-if="hasDrugsByType"
+          :loading="!dataLoaded"
           elevation="10"
           class="ma-4 pa-2"
         >
           <v-card-title>Drugs by Type</v-card-title>
-          <div class="viz-container" id="viz-drugsbytype"></div>
+          <div id="viz-drugsbytype" class="viz-container"></div>
           <v-card-text>
             <a
               href="https://ohdsi.github.io/CommonDataModel/cdm531.html#DRUG_EXPOSURE"
@@ -180,23 +180,23 @@
         </v-card>
 
         <v-card
-          :loading="!dataLoaded"
           v-if="hasRecordsByUnit"
+          :loading="!dataLoaded"
           elevation="10"
           class="ma-4 pa-2"
         >
           <v-card-title>Records by Unit</v-card-title>
-          <div class="viz-container" id="viz-recordsbyunit"></div>
+          <div id="viz-recordsbyunit" class="viz-container"></div>
         </v-card>
 
         <v-card
-          :loading="!dataLoaded"
           v-if="hasMeasurementsByType"
+          :loading="!dataLoaded"
           elevation="10"
           class="ma-4 pa-2"
         >
           <v-card-title>Measurements by Type</v-card-title>
-          <div class="viz-container" id="viz-measurementsbytype"></div>
+          <div id="viz-measurementsbytype" class="viz-container"></div>
           <v-card-text>
             <a
               href="https://ohdsi.github.io/CommonDataModel/cdm531.html#MEASUREMENT"
@@ -209,22 +209,22 @@
         </v-card>
 
         <v-card
-          :loading="!dataLoaded"
           v-if="hasAgeAtFirstOccurrence"
+          :loading="!dataLoaded"
           elevation="10"
           class="ma-4 pa-2"
         >
           <v-card-title>Age at First Occurrence</v-card-title>
-          <div class="viz-container" id="viz-ageatfirstoccurrence"></div>
+          <div id="viz-ageatfirstoccurrence" class="viz-container"></div>
           <info-panel
             details="Learn how to interpret this plot"
-            routeLink="/help"
+            route-link="/help"
           ></info-panel>
         </v-card>
 
         <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
           <v-card-title>Record Count Proportion by Month</v-card-title>
-          <div class="viz-container" id="viz-recordproportionbymonth"></div>
+          <div id="viz-recordproportionbymonth" class="viz-container"></div>
           <info-panel
             details="Proportion of people with at least one record per 1000 people."
           ></info-panel>
@@ -244,48 +244,48 @@
           <info-panel
             icon="mdi-database-clock"
             :divider="false"
-            :linkDetails="true"
-            :routeLink="getSourceConceptReportLink()"
+            :link-details="true"
+            :route-link="getSourceConceptReportLink()"
             details="Review this Time-Series across data source releases."
           ></info-panel>
         </v-card>
 
         <v-card
-          :loading="!dataLoaded"
           v-if="hasDaysSupply"
+          :loading="!dataLoaded"
           elevation="10"
           class="ma-4 pa-2"
         >
           <v-card-title>Days Supply</v-card-title>
-          <div class="viz-container" id="viz-dayssupply"></div>
+          <div id="viz-dayssupply" class="viz-container"></div>
           <info-panel
             details="Learn how to interpret this plot"
-            routeLink="/help"
+            route-link="/help"
           ></info-panel>
         </v-card>
 
         <v-card
-          :loading="!dataLoaded"
           v-if="hasQuantity"
+          :loading="!dataLoaded"
           elevation="10"
           class="ma-4 pa-2"
         >
           <v-card-title>Quantity</v-card-title>
-          <div class="viz-container" id="viz-quantity"></div>
+          <div id="viz-quantity" class="viz-container"></div>
           <info-panel
             details="Learn how to interpret this plot"
-            routeLink="/help"
+            route-link="/help"
           ></info-panel>
         </v-card>
 
         <v-card
-          :loading="!dataLoaded"
           v-if="hasVisitDurationByType"
+          :loading="!dataLoaded"
           elevation="10"
           class="ma-4 pa-2"
         >
           <v-card-title>Visit Duration by Type</v-card-title>
-          <div class="viz-container" id="viz-visitdurationbytype"></div>
+          <div id="viz-visitdurationbytype" class="viz-container"></div>
         </v-card>
 
         <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
@@ -293,8 +293,8 @@
             Record Count Proportion by Age, Sex, and Year
           </v-card-title>
           <div
-            class="viz-container"
             id="viz-recordproportionbyagesexyear"
+            class="viz-container"
           ></div>
           <info-panel
             details="Proportion of people with at least one record per 1000 people."
@@ -316,6 +316,11 @@ import dataService from "../services/DataService";
 import ReturnButton from "@/components/ReturnButton";
 
 export default {
+  components: {
+    ReturnButton,
+    error,
+    InfoPanel,
+  },
   data() {
     return {
       componentFailed: false,
@@ -1020,15 +1025,13 @@ export default {
       },
     };
   },
-  components: {
-    ReturnButton,
-    error,
-    InfoPanel,
+  computed: {},
+  watch: {
+    $route() {
+      this.load();
+    },
   },
   created() {
-    this.load();
-  },
-  updated() {
     this.load();
   },
   methods: {
@@ -1044,7 +1047,7 @@ export default {
       );
     },
     toggleMeasurementValueChart() {
-      let encoding = this.specMeasurementValueDistribution.layer[0].encoding;
+      const encoding = this.specMeasurementValueDistribution.layer[0].encoding;
 
       if (this.toggleMode === "MIN/MAX") {
         encoding.x.field = "P10_VALUE";
@@ -1092,7 +1095,8 @@ export default {
       });
     },
     load: function () {
-      let dataUrl =
+      this.dataLoaded = false;
+      const dataUrl =
         "data/" +
         this.$route.params.cdm +
         "/" +
@@ -1106,7 +1110,7 @@ export default {
         .get(dataUrl)
         .then((response) => {
           this.componentFailed = false;
-          let dateParse = d3.timeParse("%Y%m");
+          const dateParse = d3.timeParse("%Y%m");
           this.conceptData = response.data;
           this.conceptName = response.data.CONCEPT_NAME[0];
           this.conceptId = response.data.CONCEPT_ID[0];
@@ -1300,7 +1304,6 @@ export default {
         });
     },
   },
-  computed: {},
 };
 </script>
 

--- a/src/components/DataQualityHistory.vue
+++ b/src/components/DataQualityHistory.vue
@@ -2,7 +2,7 @@
   <div>
     <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
       <v-card-title>Historical Data Quality</v-card-title>
-      <div class="viz-container" id="viz-dataqualityresults"></div>
+      <div id="viz-dataqualityresults" class="viz-container"></div>
       <v-data-table
         class="viz-container"
         dense
@@ -35,12 +35,12 @@
 
     <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
       <v-card-title>Historical Data Quality by Category</v-card-title>
-      <div class="viz-container" id="viz-dataqualityresultsbycategory"></div>
+      <div id="viz-dataqualityresultsbycategory" class="viz-container"></div>
     </v-card>
 
     <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
       <v-card-title>Historical Data Quality by Domain</v-card-title>
-      <div class="viz-container" id="viz-dataqualityresultsbydomain"></div>
+      <div id="viz-dataqualityresultsbydomain" class="viz-container"></div>
     </v-card>
   </div>
 </template>
@@ -243,51 +243,54 @@ export default {
       },
     };
   },
-  created() {
-    this.load();
-  },
   watch: {
     $route() {
       this.load();
     },
   },
+  created() {
+    this.load();
+  },
   methods: {
     load: function () {
-      var vm = this;
-      var dataUrl =
+      this.dataLoaded = false;
+      this.historyRecords = [];
+      const dataUrl =
         "data/" + this.$route.params.cdm + "/data-quality-index.json";
 
       axios.get(dataUrl).then((response) => {
-        vm.dataLoaded = true;
-        var dataQualityRecords = response.data.dataQualityRecords;
+        this.dataLoaded = true;
+        let dataQualityRecords = response.data.dataQualityRecords;
         dataQualityRecords = _(dataQualityRecords)
           .orderBy("cdm_release_date")
           .reverse()
           .value();
-        vm.historyRecords = dataQualityRecords;
-        vm.specDataQualityResults.data = {
-          values: vm.historyRecords,
+        this.historyRecords = dataQualityRecords;
+        this.specDataQualityResults.data = {
+          values: this.historyRecords,
         };
-        embed("#viz-dataqualityresults", vm.specDataQualityResults).then(() => {
-          window.dispatchEvent(new Event("resize"));
-        });
+        embed("#viz-dataqualityresults", this.specDataQualityResults).then(
+          () => {
+            window.dispatchEvent(new Event("resize"));
+          }
+        );
 
-        vm.specDataQualityResultsByCategory.data = {
+        this.specDataQualityResultsByCategory.data = {
           values: response.data.dataQualityRecordsStratified,
         };
         embed(
           "#viz-dataqualityresultsbycategory",
-          vm.specDataQualityResultsByCategory
+          this.specDataQualityResultsByCategory
         ).then(() => {
           window.dispatchEvent(new Event("resize"));
         });
 
-        vm.specDataQualityResultsByDomain.data = {
+        this.specDataQualityResultsByDomain.data = {
           values: response.data.dataQualityRecordsStratified,
         };
         embed(
           "#viz-dataqualityresultsbydomain",
-          vm.specDataQualityResultsByDomain
+          this.specDataQualityResultsByDomain
         ).then(() => {
           window.dispatchEvent(new Event("resize"));
         });

--- a/src/components/DataQualityResults.vue
+++ b/src/components/DataQualityResults.vue
@@ -1,7 +1,7 @@
 <template>
   <v-responsive>
     <div v-if="componentFailed">
-      <error v-bind:text="errorText" v-bind:details="errorDetails"></error>
+      <error :text="errorText" :details="errorDetails"></error>
       <ReturnButton block />
     </div>
     <div v-if="!componentFailed">
@@ -177,17 +177,17 @@
               <v-row>
                 <v-col cols="3">
                   <v-text-field
-                    @input="delayedSearch"
                     prepend-icon="mdi-magnify"
                     label="Search in Table"
                     single-line
                     hide-details
+                    @input="delayedSearch"
                   ></v-text-field>
                 </v-col>
                 <v-col cols="auto">
                   <v-menu
-                    bottom
                     v-model="chooseHeaderMenu"
+                    bottom
                     :close-on-content-click="false"
                     :offset-y="getMenuOffset()"
                   >
@@ -211,8 +211,8 @@
                 </v-col>
                 <v-col cols="auto">
                   <v-menu
-                    bottom
                     v-model="chooseFilter"
+                    bottom
                     :close-on-content-click="false"
                     :offset-y="getMenuOffset()"
                   >
@@ -226,11 +226,11 @@
                       <v-list-item v-for="(f, i) in helpfulFilters" :key="i">
                         <v-checkbox
                           v-model="selectedFilter"
-                          v-on:change="helpfulFilterUpdate(f.preset)"
                           :label="f.text"
                           :value="f"
                           hide-details="auto"
                           :multiple="false"
+                          @change="helpfulFilterUpdate(f.preset)"
                         ></v-checkbox>
                       </v-list-item>
                     </v-list>
@@ -256,12 +256,12 @@
                   <th v-for="header in showHeaders" :key="header.text">
                     <div v-if="filters.hasOwnProperty(header.value)">
                       <v-select
+                        v-model="filters[header.value]"
                         small-chips
                         deletable-chips
                         hide-details
                         multiple
                         :items="columnValueList(header.value)"
-                        v-model="filters[header.value]"
                       ></v-select>
                     </div>
                   </th>
@@ -406,6 +406,12 @@ import { debounce } from "lodash";
 import ReturnButton from "@/components/ReturnButton";
 
 export default {
+  components: {
+    ReturnButton,
+    error,
+    codemirror,
+    infopanel,
+  },
   data: function () {
     return {
       componentFailed: false,
@@ -547,12 +553,6 @@ export default {
       },
     };
   },
-  components: {
-    ReturnButton,
-    error,
-    codemirror,
-    infopanel,
-  },
   watch: {
     $route() {
       this.load();
@@ -560,7 +560,7 @@ export default {
   },
   methods: {
     delayedSearch: debounce(function (data) {
-      this.search = data
+      this.search = data;
     }, 300),
     formatThousands: function (value) {
       return d3.format(",")(value);
@@ -589,8 +589,7 @@ export default {
       return "https://ohdsi.github.io/CommonDataModel/cdm531.html#" + table;
     },
     load: function () {
-      var self = this;
-      var dataUrl =
+      const dataUrl =
         "data/" +
         this.$route.params.cdm +
         "/" +
@@ -603,10 +602,10 @@ export default {
           this.dqResults = response.data;
           this.derivedResults = dataService.deriveResults(response.data);
           this.dataLoaded = true;
-          self.componentFailed = false;
+          this.componentFailed = false;
 
-          if (self.$route.query.conceptFailFilter) {
-            self.helpfulFilterUpdate({
+          if (this.$route.query.conceptFailFilter) {
+            this.helpfulFilterUpdate({
               FAILED: ["FAIL"],
               CDM_TABLE_NAME: [],
               CDM_FIELD_NAME: [],
@@ -617,13 +616,13 @@ export default {
               CONTEXT: [],
               CHECK_LEVEL: [],
             });
-            self.search = self.$route.query.conceptFailFilter;
+            this.search = this.$route.query.conceptFailFilter;
           }
-          if (self.$route.query.domainFailFilter) {
-            self.helpfulFilterUpdate({
+          if (this.$route.query.domainFailFilter) {
+            this.helpfulFilterUpdate({
               FAILED: ["FAIL"],
               CDM_TABLE_NAME: [
-                self.$route.query.domainFailFilter.toUpperCase(),
+                this.$route.query.domainFailFilter.toUpperCase(),
               ],
               CDM_FIELD_NAME: [],
               CHECK_NAME: [],
@@ -634,21 +633,21 @@ export default {
               CHECK_LEVEL: [],
             });
           }
-          if (self.$route.query.categoryFailFilter) {
-            self.helpfulFilterUpdate({
+          if (this.$route.query.categoryFailFilter) {
+            this.helpfulFilterUpdate({
               FAILED: ["FAIL"],
               CDM_TABLE_NAME: [],
               CDM_FIELD_NAME: [],
               CHECK_NAME: [],
               NOTES_EXIST: [],
-              CATEGORY: [self.$route.query.categoryFailFilter.toUpperCase()],
+              CATEGORY: [this.$route.query.categoryFailFilter.toUpperCase()],
               SUBCATEGORY: [],
               CONTEXT: [],
               CHECK_LEVEL: [],
             });
           }
-          if (self.$route.query.failFilter) {
-            self.helpfulFilterUpdate({
+          if (this.$route.query.failFilter) {
+            this.helpfulFilterUpdate({
               FAILED: ["FAIL"],
               CDM_TABLE_NAME: [],
               CDM_FIELD_NAME: [],
@@ -662,9 +661,9 @@ export default {
           }
         })
         .catch((err) => {
-          self.componentFailed = true;
-          self.errorText = "Failed to load data quality results file.";
-          self.errorDetails = err + " (" + dataUrl + ")";
+          this.componentFailed = true;
+          this.errorText = "Failed to load data quality results file.";
+          this.errorDetails = err + " (" + dataUrl + ")";
         });
     },
     columnValueList(val) {
@@ -672,7 +671,7 @@ export default {
     },
     renderDescription: function (d) {
       let thresholdMessage = "";
-      if (d.THRESHOLD_VALUE != undefined) {
+      if (d.THRESHOLD_VALUE !== undefined) {
         thresholdMessage = " (Threshold=" + d.THRESHOLD_VALUE + "%).";
       }
       return d.CHECK_DESCRIPTION + thresholdMessage;

--- a/src/components/DomainContinuity.vue
+++ b/src/components/DomainContinuity.vue
@@ -2,7 +2,7 @@
   <v-responsive min-width="900">
     <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
       <v-card-title>Domain Continuity</v-card-title>
-      <div class="viz-container" id="viz-continuity"></div>
+      <div id="viz-continuity" class="viz-container"></div>
       <info-panel
         details="Domain continuity shows the number of records in each domain table for multiple releases of data from a specific vendor or data source. This is NOT the number of records that occur at specific times within a CDM, but a count of the number of records in a release of a data source, graphed over time. This visualization allows one to see how the data is changing across updates for a single data source."
       ></info-panel>
@@ -16,6 +16,9 @@ import axios from "axios";
 import InfoPanel from "./InfoPanel.vue";
 
 export default {
+  components: {
+    InfoPanel,
+  },
   data() {
     return {
       dataLoaded: false,
@@ -72,32 +75,29 @@ export default {
       },
     };
   },
-  components: {
-    InfoPanel,
-  },
-  created() {
-    this.load();
-  },
   watch: {
     $route() {
       this.load();
     },
   },
+  created() {
+    this.load();
+  },
   methods: {
     load: function () {
-      var vm = this;
-      var dataUrl =
+      this.dataLoaded = false;
+      const dataUrl =
         "data/" + this.$route.params.cdm + "/data-source-history-index.json";
 
       axios.get(dataUrl).then((response) => {
-        vm.dataLoaded = true;
-        vm.specOverview.data = {
+        this.dataLoaded = true;
+        this.specOverview.data = {
           values: response.data.domainRecords,
         };
-        embed("#viz-continuity", vm.specOverview).then(() => {
+        embed("#viz-continuity", this.specOverview).then(() => {
           window.dispatchEvent(new Event("resize"));
         });
-        vm.dataLoaded = true;
+        this.dataLoaded = true;
       });
     },
   },

--- a/src/components/DomainDensity.vue
+++ b/src/components/DomainDensity.vue
@@ -2,12 +2,12 @@
   <div>
     <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
       <v-card-title>Domain Density</v-card-title>
-      <div style="width: 80%" id="viz-overview"></div>
+      <div id="viz-overview" style="width: 80%"></div>
     </v-card>
 
     <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
       <v-card-title>Domain Records per Person</v-card-title>
-      <div style="width: 80%" id="viz-recordsperperson"></div>
+      <div id="viz-recordsperperson" style="width: 80%"></div>
     </v-card>
   </div>
 </template>
@@ -235,6 +235,7 @@ export default {
       },
     };
   },
+  computed: {},
   watch: {
     $route() {
       this.load();
@@ -248,17 +249,17 @@ export default {
       window.dispatchEvent(new Event("resize"));
     },
     load: function () {
-      var self = this;
-      var dataRequests = [];
+      this.dataLoaded = false;
+      const dataRequests = [];
 
-      var urlRecordsPerPerson =
+      const urlRecordsPerPerson =
         "data/" +
         this.$route.params.cdm +
         "/" +
         this.$route.params.release +
         "/datadensity-records-per-person.csv";
 
-      var urlOverview =
+      const urlOverview =
         "data/" +
         this.$route.params.cdm +
         "/" +
@@ -270,21 +271,20 @@ export default {
 
       axios.all(dataRequests).then(
         axios.spread((...responses) => {
-          self.defRecordsPerPerson.data = {
+          this.defRecordsPerPerson.data = {
             values: d3Import.csvParse(responses[0].data),
           };
-          self.defOverview.data = {
+          this.defOverview.data = {
             values: d3Import.csvParse(responses[1].data),
           };
 
-          embed("#viz-overview", self.defOverview);
-          embed("#viz-recordsperperson", self.defRecordsPerPerson);
-          self.dataLoaded = true;
+          embed("#viz-overview", this.defOverview);
+          embed("#viz-recordsperperson", this.defRecordsPerPerson);
+          this.dataLoaded = true;
         })
       );
     },
   },
-  computed: {},
 };
 </script>
 

--- a/src/components/MetadataReport.vue
+++ b/src/components/MetadataReport.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-if="componentFailed">
-      <error v-bind:text="errorText" v-bind:details="errorDetails"></error>
+      <error :text="errorText" :details="errorDetails"></error>
       <ReturnButton block />
     </div>
     <v-card :loading="!cdmsourceDataLoaded" elevation="10" class="ma-4 pa-2">
@@ -45,6 +45,13 @@ import error from "./Error.vue";
 import ReturnButton from "@/components/ReturnButton";
 
 export default {
+  components: {
+    error,
+    ReturnButton,
+  },
+  props: {
+    resultFile: String,
+  },
   data: function () {
     return {
       cdmsourceData: null,
@@ -54,15 +61,18 @@ export default {
       componentFailed: false,
       errorText: "",
       errorDetails: "",
-      dataLoaded: false,
       domainTable: [],
       search: "",
     };
   },
+  computed: {},
   watch: {
     $route() {
       this.load();
     },
+  },
+  created() {
+    this.load();
   },
   methods: {
     getMenuOffset: function () {
@@ -72,14 +82,15 @@ export default {
       return this.domainTable.map((d) => d[val]);
     },
     load() {
-      var self = this;
-      var metadataUrl =
+      this.metadataDataLoaded = false;
+      this.cdmsourceDataLoaded = false;
+      const metadataUrl =
         "data/" +
         this.$route.params.cdm +
         "/" +
         this.$route.params.release +
         "/metadata.csv";
-      var cdmsourceUrl =
+      const cdmsourceUrl =
         "data/" +
         this.$route.params.cdm +
         "/" +
@@ -89,40 +100,29 @@ export default {
       axios
         .get(metadataUrl)
         .then((response) => {
-          self.metadataData = d3.csvParse(response.data);
-          self.metadataDataLoaded = true;
-          self.componentFailed = false;
+          this.metadataData = d3.csvParse(response.data);
+          this.metadataDataLoaded = true;
+          this.componentFailed = false;
         })
         .catch((err) => {
-          self.componentFailed = true;
-          self.errorText = "Failed to obtain metadata table data file.";
-          self.errorDetails = err + ". (" + metadataUrl + ")";
+          this.componentFailed = true;
+          this.errorText = "Failed to obtain metadata table data file.";
+          this.errorDetails = err + ". (" + metadataUrl + ")";
         });
 
       axios
         .get(cdmsourceUrl)
         .then((response) => {
-          self.cdmsourceData = d3.csvParse(response.data);
-          self.cdmsourceDataLoaded = true;
-          self.componentFailed = false;
+          this.cdmsourceData = d3.csvParse(response.data);
+          this.cdmsourceDataLoaded = true;
+          this.componentFailed = false;
         })
         .catch((err) => {
-          self.componentFailed = true;
-          self.errorText = "Failed to obtain cdmsource table data file.";
-          self.errorDetails = err + ". (" + cdmsourceUrl + ")";
+          this.componentFailed = true;
+          this.errorText = "Failed to obtain cdmsource table data file.";
+          this.errorDetails = err + ". (" + cdmsourceUrl + ")";
         });
     },
-  },
-  created() {
-    this.load();
-  },
-  components: {
-    error,
-    ReturnButton
-  },
-  computed: {},
-  props: {
-    resultFile: String,
   },
 };
 </script>

--- a/src/components/ObservationPeriodReport.vue
+++ b/src/components/ObservationPeriodReport.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-if="componentFailed">
-      <error v-bind:text="errorText" v-bind:details="errorDetails"></error>
+      <error :text="errorText" :details="errorDetails"></error>
       <ReturnButton block />
     </div>
     <v-container v-if="!componentFailed">
@@ -9,11 +9,11 @@
         <div class="text-uppercase text-h6">Observation Period Report</div>
         <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
           <v-card-title>Cumulative Observation</v-card-title>
-          <div class="viz-container" id="viz-cumulativeobservation"></div>
+          <div id="viz-cumulativeobservation" class="viz-container"></div>
         </v-card>
         <v-card
-          :loading="!dataLoaded"
           v-if="dataLoaded"
+          :loading="!dataLoaded"
           elevation="10"
           class="ma-4 pa-2"
         >
@@ -34,23 +34,23 @@
         </v-card>
         <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
           <v-card-title>Observation over Time</v-card-title>
-          <div class="viz-container" id="viz-observationbymonth"></div>
+          <div id="viz-observationbymonth" class="viz-container"></div>
         </v-card>
         <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
           <v-card-title>Years of Observation by Age</v-card-title>
-          <div class="viz-container" id="viz-observationbyage"></div>
+          <div id="viz-observationbyage" class="viz-container"></div>
         </v-card>
         <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
           <v-card-title>Years of Observation by Sex</v-card-title>
-          <div class="viz-container" id="viz-observationbysex"></div>
+          <div id="viz-observationbysex" class="viz-container"></div>
         </v-card>
         <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
           <v-card-title>Age at First Observation</v-card-title>
-          <div class="viz-container" id="viz-ageatfirstobservation"></div>
+          <div id="viz-ageatfirstobservation" class="viz-container"></div>
         </v-card>
         <v-card :loading="!dataLoaded" elevation="10" class="ma-4 pa-2">
           <v-card-title>Age at First Observation by Sex</v-card-title>
-          <div class="viz-container" id="viz-agebysex"></div>
+          <div id="viz-agebysex" class="viz-container"></div>
         </v-card>
       </v-responsive>
     </v-container>
@@ -66,6 +66,10 @@ import dataService from "../services/DataService";
 import ReturnButton from "@/components/ReturnButton";
 
 export default {
+  components: {
+    ReturnButton,
+    error,
+  },
   data() {
     return {
       componentFailed: false,
@@ -353,10 +357,7 @@ export default {
       },
     };
   },
-  components: {
-    ReturnButton,
-    error,
-  },
+  computed: {},
   watch: {
     $route() {
       this.load();
@@ -370,8 +371,9 @@ export default {
       window.dispatchEvent(new Event("resize"));
     },
     load: function () {
-      let dateParse = d3.timeParse("%Y%m");
-      let dataUrl =
+      this.dataLoaded = false;
+      const dateParse = d3.timeParse("%Y%m");
+      const dataUrl =
         "data/" +
         this.$route.params.cdm +
         "/" +
@@ -433,7 +435,6 @@ export default {
         });
     },
   },
-  computed: {},
 };
 </script>
 

--- a/src/components/UnmappedSourceCodes.vue
+++ b/src/components/UnmappedSourceCodes.vue
@@ -179,6 +179,8 @@ export default {
       );
     },
     load() {
+      this.dataLoaded = false;
+      this.domainTable = [];
       const dataUrl =
         "data/" +
         this.$route.params.cdm +


### PR DESCRIPTION
Closes https://github.com/OHDSI/Ares/issues/70

Added loading indicator to every table and chart that could be updated with explorer. The tables' data cleares on source change. As the charts require reembedding to be updated, they just display the icon.

Fixed the Death component not reloading on source change.