### PR TITLE
Network performance report fails to load

### DIFF
--- a/src/interface/components/Pivot/Pivot.vue
+++ b/src/interface/components/Pivot/Pivot.vue
@@ -230,9 +230,6 @@ export default {
   },
 
   computed: {
-    getUniqueAttributes: function () {
-      return [...new Set(...this.data.map((obj) => Object.keys(obj)))];
-    },
     getUniqueAttributeValues: function () {
       return this.getDisplayedAttributes.reduce(
         (prevState, currAttribute) => ({
@@ -245,11 +242,7 @@ export default {
       );
     },
     getDisplayedAttributes: function () {
-      if (this.attributes.length) {
-        return this.attributes;
-      } else {
-        return this.getUniqueAttributes;
-      }
+      return this.attributes;
     },
   },
   methods: {

--- a/src/interface/views/network/NetworkPerformance.vue
+++ b/src/interface/views/network/NetworkPerformance.vue
@@ -1,7 +1,17 @@
 <template>
   <v-container fluid>
     <v-card>
-      <Pivot :data="getData['networkPerformance']" />
+      <Pivot
+        :data="getData['networkPerformance']"
+        :attributes="[
+          'TASK',
+          'TIMING',
+          'PACKAGE',
+          'CATEGORY',
+          'SOURCE',
+          'RELEASE',
+        ]"
+      />
     </v-card>
   </v-container>
 </template>


### PR DESCRIPTION
Closes https://github.com/OHDSI/Ares/issues/143

Seems like the issue only affected Chrome as its default call stack size is smaller than that of Firefox for example.