### PR TITLE
Data density report chart error 

### DIFF
--- a/src/data/store/modules/view/postprocessing/dataDensity.js
+++ b/src/data/store/modules/view/postprocessing/dataDensity.js
@@ -5,7 +5,7 @@ import {
 
 export default function dataDensity(data) {
   return {
-    domainDensity: data[DENSITY_RECORDS_PERSON],
-    domainRecords: data[DENSITY_TOTAL],
+    domainDensity: data[DENSITY_TOTAL],
+    domainRecords: data[DENSITY_RECORDS_PERSON],
   };
 }


### PR DESCRIPTION
Closes https://github.com/OHDSI/Ares/issues/149

The issue is fixed. The charts showed valued that were meant for another.