### PR TITLE
Observation period report numbers should be right aligned

### DIFF
--- a/src/pages/reports/release/ObservationPeriodReport.vue
+++ b/src/pages/reports/release/ObservationPeriodReport.vue
@@ -242,7 +242,7 @@ const headers: Ref<DataTableHeader[]> = ref([
     title: "Number of People",
     sortable: true,
     key: "COUNT_VALUE",
-    align: "start",
+    align: "end",
   },
   {
     title: "% of People",


### PR DESCRIPTION
Closes https://github.com/OHDSI/Ares/issues/226

Changed Number of People column's alignment to right