### PR TITLE
DomainTable fails to load if domain-drug-stratification.csv is missing

### DIFF
--- a/src/pages/reports/release/DomainTable.vue
+++ b/src/pages/reports/release/DomainTable.vue
@@ -181,7 +181,10 @@
       ></info-panel>
     </v-card>
     <v-card
-      v-if="route.params.domain.toUpperCase() === 'DRUG_EXPOSURE'"
+      v-if="
+        route.params.domain.toUpperCase() === 'DRUG_EXPOSURE' &&
+        store.getters.getData.drugStratification
+      "
       :loading="!store.getters.dataInStore"
       elevation="10"
       class="ma-4 pa-2"

--- a/src/processes/exploreReports/model/store/data.module.ts
+++ b/src/processes/exploreReports/model/store/data.module.ts
@@ -52,14 +52,14 @@ const actions = {
       const data = responses.reduce((obj, currValue, index) => {
         const status = currValue.status;
         if (status === "fulfilled") {
-          const data = currValue.value?.data;
+          const fileData = currValue.value?.data;
           return {
             ...obj,
             [payload.files[index].name]: preprocessing[
               payload.files[index].name
             ]
-              ? preprocessing[payload.files[index].name](data)
-              : data,
+              ? preprocessing[payload.files[index].name](fileData)
+              : fileData,
           };
         }
         if (status === "rejected" && currValue.reason.payload.required) {
@@ -69,6 +69,13 @@ const actions = {
             message,
             details: url,
           });
+          return {
+            ...obj,
+          };
+        } else {
+          return {
+            ...obj,
+          };
         }
       }, {});
       postprocessing[rootState.route.name]


### PR DESCRIPTION
Closes https://github.com/OHDSI/Ares/issues/245

The reason was that one case (file isn't required by the app and it is rejected) wasn't handled by the data loading function.

Should now be fixed.