### PR TITLE
Blank screen when index.json is missing

### DIFF
--- a/src/widgets/explorer/model/store/explorer.module.ts
+++ b/src/widgets/explorer/model/store/explorer.module.ts
@@ -82,8 +82,8 @@ const actions = {
       })
       .catch((error) => {
         dispatch(errorActions.NEW_ERROR, {
-          message: error.error.message,
-          details: error.error.response.request.responseURL,
+          message: "Unable to load data source index file",
+          details: error.message,
         });
       });
   },
@@ -93,12 +93,6 @@ const actions = {
     }).then((response) => {
       commit(LOAD_QUERY_INDEX, response.data);
     });
-    /* .catch((error) => {
-        dispatch(errorActions.NEW_ERROR, {
-          message: error.error.message,
-          details: error.error.response.request.responseURL,
-        });
-      });*/
   },
 };
 


### PR DESCRIPTION
Closes https://github.com/OHDSI/Ares/issues/323

The error handler was unable to find required data to show the error message so it didn'nt render. Fixed.