### PR TITLE
network population overview chart issues

### DIFF
--- a/src/pages/reports/network/NetworkPopulationReport/charts/ageAtFirstObservation/specAgeAtFirstObservation.ts
+++ b/src/pages/reports/network/NetworkPopulationReport/charts/ageAtFirstObservation/specAgeAtFirstObservation.ts
@@ -47,13 +47,23 @@ export function specAgeAtFirstObservation(zeroBaseline = false) {
       },
       {
         selection: {
+          dataSource: {
+            type: "multi",
+            fields: ["DATA_SOURCE_KEY"],
+            bind: "legend",
+          },
           x: {
             type: "single",
             on: "mousemove",
-            encodings: ["x"],
+            fields: ["INTERVAL_INDEX"],
             nearest: true,
           },
         },
+        transform: [
+          {
+            filter: { selection: "dataSource" },
+          },
+        ],
         mark: { type: "point", tooltip: true },
       },
       {
@@ -63,6 +73,7 @@ export function specAgeAtFirstObservation(zeroBaseline = false) {
               and: ["x.INTERVAL_INDEX", { selection: "x" }],
             },
           },
+          { filter: { selection: "dataSource" } },
         ],
         layer: [
           {

--- a/src/pages/reports/network/NetworkPopulationReport/charts/cumulativeObservation/specCumulativeObservation.ts
+++ b/src/pages/reports/network/NetworkPopulationReport/charts/cumulativeObservation/specCumulativeObservation.ts
@@ -47,13 +47,23 @@ export function specCumulativeObservation(zeroBaseline = false) {
       },
       {
         selection: {
+          dataSource: {
+            type: "multi",
+            fields: ["DATA_SOURCE_KEY"],
+            bind: "legend",
+          },
           x: {
             type: "single",
             on: "mousemove",
-            encodings: ["x"],
+            fields: ["YEARS"],
             nearest: true,
           },
         },
+        transform: [
+          {
+            filter: { selection: "dataSource" },
+          },
+        ],
         mark: { type: "point", tooltip: true },
       },
       {
@@ -63,6 +73,7 @@ export function specCumulativeObservation(zeroBaseline = false) {
               and: ["x.YEARS", { selection: "x" }],
             },
           },
+          { filter: { selection: "dataSource" } },
         ],
         layer: [
           {


### PR DESCRIPTION
closes https://github.com/OHDSI/Ares/issues/329

Fixed chart legends not filtering data.

Tooltip can only show 1 data point at a time and will stick to the nearest point which means multi-selection isn't an option.