### PR TITLE
Visit Occurrence and Visit Detail domain report tables are randomly sorted (development version)

### DIFF
--- a/src/pages/reports/release/DomainTable/components/MainTable.vue
+++ b/src/pages/reports/release/DomainTable/components/MainTable.vue
@@ -17,6 +17,8 @@
     </template>
     <div class="p-5">
       <DataTable
+        sortField="PERCENT_PERSONS"
+        :sortOrder="-1"
         size="small"
         :value="store.getters.getData.domainTable"
         paginator


### PR DESCRIPTION
Closes https://github.com/OHDSI/Ares/issues/390

In the dev version of Ares sorting is disabled by default. The data renders in the order specified within the domain-summary file.

Added presort for the "% People" column to all domain reports.