### PR TITLE
improvement: remove the @mdi/font cdn link

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <link rel="icon" id="faviconTag" type="image/png" href="/favicon-light.png">
     <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/@mdi/font@5.x/css/materialdesignicons.min.css" rel="stylesheet">
   <title>ARES</title>
 </head>
 


### PR DESCRIPTION
Hi 👋 

This PR removes an unused CDN link for "Material Design Icons webfont" as the project uses `@mdi/js`(which lazy loads the SVG paths). Public CDNs pose security risks and are discouraged, aligning with secure deployment practices.

More information here: https://pictogrammers.com/docs/guides/webfont-alternatives/
and here: https://dev.to/rstacruz/public-cdns-arent-useful-anymore-2b66